### PR TITLE
fix the foreign key issue in `load_dept_manager.dump` data load

### DIFF
--- a/load_dept_manager.dump
+++ b/load_dept_manager.dump
@@ -1,4 +1,4 @@
-INSERT INTO `dept_manager` VALUES 
+INSERT INTO `dept_manager`(emp_no, dept_no,from_date, to_date) VALUES 
 (110022,'d001','1985-01-01','1991-10-01'),
 
 (110039,'d001','1991-10-01','9999-01-01'),


### PR DESCRIPTION
#### Fix Foreign key issues
- explicitly specify the column names to be populated in the table

#### Cause of foreign key issue
Tried loading data using the below command
```sql
$ mysql db_test1 -u root < load_dept_manager.dump
```
Reported Error:
```
ERROR 1452 (23000) at line 1: Cannot add or update a child row: a foreign key constraint fails (`db_test1`.`dept_manager`, CONSTRAINT `dept_manager_ibfk_1` FOREIGN KEY (`emp_no`) REFERENCES `employees` (`emp_no`) ON DELETE CASCADE)
```
When opened and viewed the `dept_manager` the column order were not matching and thus specifying column order explicitly in insert query fixes the problem.