### PR TITLE
Fix dbdeployer install: move binary to /usr/local/bin

### DIFF
--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dbdeployer
         run: |
           curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
-          echo "$HOME/bin" >> "$GITHUB_PATH"
+          sudo mv dbdeployer /usr/local/bin/dbdeployer
 
       - name: Cache MariaDB tarball
         uses: actions/cache@v4

--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -18,6 +18,7 @@ jobs:
         mariadb-version:
           - '10.11.9'
           - '11.4.5'
+          - '12.1.2'
     env:
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql
       MARIADB_VERSION: ${{ matrix.mariadb-version }}

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -18,7 +18,10 @@ jobs:
         mysql-version:
           - '8.0.42'
           - '8.4.8'
+          - '9.0.1'
+          - '9.2.0'
           - '9.5.0'
+          - '9.6.0'
     env:
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql
       MYSQL_VERSION: ${{ matrix.mysql-version }}
@@ -40,27 +43,36 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/mysql-tarball
-          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v1
+          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v2
 
       - name: Download MySQL
         run: |
           SHORT_VER="${MYSQL_VERSION%.*}"
-          TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
           mkdir -p /tmp/mysql-tarball
-          if [ ! -f "/tmp/mysql-tarball/$TARBALL" ]; then
-            echo "Downloading $TARBALL..."
-            curl -L -f -o "/tmp/mysql-tarball/$TARBALL" \
-              "https://dev.mysql.com/get/Downloads/MySQL-${SHORT_VER}/$TARBALL" \
-              || curl -L -f -o "/tmp/mysql-tarball/$TARBALL" \
-              "https://downloads.mysql.com/archives/get/p/23/file/$TARBALL"
+          CACHED=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz 2>/dev/null | head -1)
+          if [ -n "$CACHED" ]; then
+            echo "Using cached tarball: $CACHED"
+            ls -lh "$CACHED"
+            exit 0
           fi
-          ls -lh "/tmp/mysql-tarball/$TARBALL"
+          # Try glibc2.17 first, then glibc2.28 (needed for MySQL 9.6+)
+          for GLIBC in glibc2.17 glibc2.28; do
+            TARBALL="mysql-${MYSQL_VERSION}-linux-${GLIBC}-x86_64.tar.xz"
+            URL="https://dev.mysql.com/get/Downloads/MySQL-${SHORT_VER}/${TARBALL}"
+            echo "Trying ${GLIBC}..."
+            if curl -L -f -o "/tmp/mysql-tarball/$TARBALL" "$URL"; then
+              ls -lh "/tmp/mysql-tarball/$TARBALL"
+              exit 0
+            fi
+          done
+          echo "ERROR: Could not download MySQL ${MYSQL_VERSION}"
+          exit 1
 
       - name: Unpack MySQL
         run: |
           mkdir -p "$SANDBOX_BINARY"
-          TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
-          dbdeployer unpack "/tmp/mysql-tarball/$TARBALL" \
+          TARBALL=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz | head -1)
+          dbdeployer unpack "$TARBALL" \
             --sandbox-binary="$SANDBOX_BINARY"
 
       - name: Deploy sandbox
@@ -109,13 +121,10 @@ jobs:
       - name: Test stored procedures
         run: |
           SBDIR=$(ls -d ~/sandboxes/msb_*)
-          # Test functions
           $SBDIR/use -BN -e "SELECT emp_name(10001);" employees
           $SBDIR/use -BN -e "SELECT emp_dept_name(10001);" employees
           $SBDIR/use -BN -e "SELECT current_manager('d001');" employees
-          # Test procedure
           $SBDIR/use -t -e "CALL show_departments();" employees
-          # Test views
           $SBDIR/use -BN -e "SELECT COUNT(*) FROM v_full_employees;" employees
           $SBDIR/use -BN -e "SELECT COUNT(*) FROM v_full_departments;" employees
 
@@ -134,7 +143,10 @@ jobs:
         mysql-version:
           - '8.0.42'
           - '8.4.8'
+          - '9.0.1'
+          - '9.2.0'
           - '9.5.0'
+          - '9.6.0'
     env:
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql
       MYSQL_VERSION: ${{ matrix.mysql-version }}
@@ -156,27 +168,35 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/mysql-tarball
-          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v1
+          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v2
 
       - name: Download MySQL
         run: |
           SHORT_VER="${MYSQL_VERSION%.*}"
-          TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
           mkdir -p /tmp/mysql-tarball
-          if [ ! -f "/tmp/mysql-tarball/$TARBALL" ]; then
-            echo "Downloading $TARBALL..."
-            curl -L -f -o "/tmp/mysql-tarball/$TARBALL" \
-              "https://dev.mysql.com/get/Downloads/MySQL-${SHORT_VER}/$TARBALL" \
-              || curl -L -f -o "/tmp/mysql-tarball/$TARBALL" \
-              "https://downloads.mysql.com/archives/get/p/23/file/$TARBALL"
+          CACHED=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz 2>/dev/null | head -1)
+          if [ -n "$CACHED" ]; then
+            echo "Using cached tarball: $CACHED"
+            ls -lh "$CACHED"
+            exit 0
           fi
-          ls -lh "/tmp/mysql-tarball/$TARBALL"
+          for GLIBC in glibc2.17 glibc2.28; do
+            TARBALL="mysql-${MYSQL_VERSION}-linux-${GLIBC}-x86_64.tar.xz"
+            URL="https://dev.mysql.com/get/Downloads/MySQL-${SHORT_VER}/${TARBALL}"
+            echo "Trying ${GLIBC}..."
+            if curl -L -f -o "/tmp/mysql-tarball/$TARBALL" "$URL"; then
+              ls -lh "/tmp/mysql-tarball/$TARBALL"
+              exit 0
+            fi
+          done
+          echo "ERROR: Could not download MySQL ${MYSQL_VERSION}"
+          exit 1
 
       - name: Unpack MySQL
         run: |
           mkdir -p "$SANDBOX_BINARY"
-          TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
-          dbdeployer unpack "/tmp/mysql-tarball/$TARBALL" \
+          TARBALL=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz | head -1)
+          dbdeployer unpack "$TARBALL" \
             --sandbox-binary="$SANDBOX_BINARY"
 
       - name: Deploy sandbox
@@ -193,13 +213,11 @@ jobs:
       - name: Verify partitioning
         run: |
           SBDIR=$(ls -d ~/sandboxes/msb_*)
-          # Verify partitions exist on titles
           PART_COUNT=$($SBDIR/use -BN -e \
             "SELECT COUNT(*) FROM information_schema.partitions WHERE table_schema='employees' AND table_name='titles';" \
             employees)
           echo "titles partitions: $PART_COUNT"
           [ "$PART_COUNT" -ge 18 ] || { echo "FAIL: expected >= 18 partitions on titles"; exit 1; }
-          # Verify partitions exist on salaries
           PART_COUNT=$($SBDIR/use -BN -e \
             "SELECT COUNT(*) FROM information_schema.partitions WHERE table_schema='employees' AND table_name='salaries';" \
             employees)
@@ -234,7 +252,10 @@ jobs:
         mysql-version:
           - '8.0.42'
           - '8.4.8'
+          - '9.0.1'
+          - '9.2.0'
           - '9.5.0'
+          - '9.6.0'
     env:
       SANDBOX_BINARY: ${{ github.workspace }}/opt/mysql
       MYSQL_VERSION: ${{ matrix.mysql-version }}
@@ -256,27 +277,35 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/mysql-tarball
-          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v1
+          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v2
 
       - name: Download MySQL
         run: |
           SHORT_VER="${MYSQL_VERSION%.*}"
-          TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
           mkdir -p /tmp/mysql-tarball
-          if [ ! -f "/tmp/mysql-tarball/$TARBALL" ]; then
-            echo "Downloading $TARBALL..."
-            curl -L -f -o "/tmp/mysql-tarball/$TARBALL" \
-              "https://dev.mysql.com/get/Downloads/MySQL-${SHORT_VER}/$TARBALL" \
-              || curl -L -f -o "/tmp/mysql-tarball/$TARBALL" \
-              "https://downloads.mysql.com/archives/get/p/23/file/$TARBALL"
+          CACHED=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz 2>/dev/null | head -1)
+          if [ -n "$CACHED" ]; then
+            echo "Using cached tarball: $CACHED"
+            ls -lh "$CACHED"
+            exit 0
           fi
-          ls -lh "/tmp/mysql-tarball/$TARBALL"
+          for GLIBC in glibc2.17 glibc2.28; do
+            TARBALL="mysql-${MYSQL_VERSION}-linux-${GLIBC}-x86_64.tar.xz"
+            URL="https://dev.mysql.com/get/Downloads/MySQL-${SHORT_VER}/${TARBALL}"
+            echo "Trying ${GLIBC}..."
+            if curl -L -f -o "/tmp/mysql-tarball/$TARBALL" "$URL"; then
+              ls -lh "/tmp/mysql-tarball/$TARBALL"
+              exit 0
+            fi
+          done
+          echo "ERROR: Could not download MySQL ${MYSQL_VERSION}"
+          exit 1
 
       - name: Unpack MySQL
         run: |
           mkdir -p "$SANDBOX_BINARY"
-          TARBALL="mysql-${MYSQL_VERSION}-linux-glibc2.17-x86_64.tar.xz"
-          dbdeployer unpack "/tmp/mysql-tarball/$TARBALL" \
+          TARBALL=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz | head -1)
+          dbdeployer unpack "$TARBALL" \
             --sandbox-binary="$SANDBOX_BINARY"
 
       - name: Deploy sandbox
@@ -299,13 +328,11 @@ jobs:
       - name: Verify Sakila data
         run: |
           SBDIR=$(ls -d ~/sandboxes/msb_*)
-          # Verify core tables have data
           for table in actor film customer rental payment staff store; do
             COUNT=$($SBDIR/use -BN -e "SELECT COUNT(*) FROM $table;" sakila)
             echo "$table: $COUNT rows"
             [ "$COUNT" -gt 0 ] || { echo "FAIL: $table is empty"; exit 1; }
           done
-          # Verify views work
           $SBDIR/use -BN -e "SELECT COUNT(*) FROM film_list;" sakila
           $SBDIR/use -BN -e "SELECT COUNT(*) FROM customer_list;" sakila
 

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -80,16 +80,36 @@ jobs:
           dbdeployer deploy single "$MYSQL_VERSION" \
             --sandbox-binary="$SANDBOX_BINARY"
 
+      - name: Detect MySQL features
+        id: features
+        run: |
+          # --commands flag only exists in MySQL 9.5+ (SOURCE default changed to FALSE)
+          MAJOR=$(echo "$MYSQL_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$MYSQL_VERSION" | cut -d. -f2)
+          NEEDS_COMMANDS="false"
+          if [ "$MAJOR" -gt 9 ] || { [ "$MAJOR" -eq 9 ] && [ "$MINOR" -ge 5 ]; }; then
+            NEEDS_COMMANDS="true"
+          fi
+          # Check if MD5() is available (removed in MySQL 9.6+)
+          HAS_MD5="true"
+          if [ "$MAJOR" -gt 9 ] || { [ "$MAJOR" -eq 9 ] && [ "$MINOR" -ge 6 ]; }; then
+            HAS_MD5="false"
+          fi
+          echo "needs_commands=$NEEDS_COMMANDS" >> "$GITHUB_OUTPUT"
+          echo "has_md5=$HAS_MD5" >> "$GITHUB_OUTPUT"
+          echo "MySQL $MYSQL_VERSION: needs_commands=$NEEDS_COMMANDS, has_md5=$HAS_MD5"
+
       - name: Load employees database
         run: |
           EXTRA_ARGS=""
-          [[ "$MYSQL_VERSION" == 9.* ]] && EXTRA_ARGS="--commands"
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
           ~/sandboxes/msb_*/use $EXTRA_ARGS < employees.sql
 
       - name: Test MD5 integrity
+        if: steps.features.outputs.has_md5 == 'true'
         run: |
           EXTRA_ARGS=""
-          [[ "$MYSQL_VERSION" == 9.* ]] && EXTRA_ARGS="--commands"
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
           ~/sandboxes/msb_*/use $EXTRA_ARGS -t < test_employees_md5.sql > /tmp/test_md5.txt
           cat /tmp/test_md5.txt
           md5_ok=$(grep -iw ok /tmp/test_md5.txt | wc -l | tr -d ' \t')
@@ -102,7 +122,7 @@ jobs:
       - name: Test SHA integrity
         run: |
           EXTRA_ARGS=""
-          [[ "$MYSQL_VERSION" == 9.* ]] && EXTRA_ARGS="--commands"
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
           ~/sandboxes/msb_*/use $EXTRA_ARGS -t < test_employees_sha.sql > /tmp/test_sha.txt
           cat /tmp/test_sha.txt
           sha_ok=$(grep -iw ok /tmp/test_sha.txt | wc -l | tr -d ' \t')
@@ -115,7 +135,7 @@ jobs:
       - name: Load objects (stored procedures/functions)
         run: |
           EXTRA_ARGS=""
-          [[ "$MYSQL_VERSION" == 9.* ]] && EXTRA_ARGS="--commands"
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
           ~/sandboxes/msb_*/use $EXTRA_ARGS < objects.sql
 
       - name: Test stored procedures
@@ -204,10 +224,26 @@ jobs:
           dbdeployer deploy single "$MYSQL_VERSION" \
             --sandbox-binary="$SANDBOX_BINARY"
 
+      - name: Detect MySQL features
+        id: features
+        run: |
+          MAJOR=$(echo "$MYSQL_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$MYSQL_VERSION" | cut -d. -f2)
+          NEEDS_COMMANDS="false"
+          if [ "$MAJOR" -gt 9 ] || { [ "$MAJOR" -eq 9 ] && [ "$MINOR" -ge 5 ]; }; then
+            NEEDS_COMMANDS="true"
+          fi
+          HAS_MD5="true"
+          if [ "$MAJOR" -gt 9 ] || { [ "$MAJOR" -eq 9 ] && [ "$MINOR" -ge 6 ]; }; then
+            HAS_MD5="false"
+          fi
+          echo "needs_commands=$NEEDS_COMMANDS" >> "$GITHUB_OUTPUT"
+          echo "has_md5=$HAS_MD5" >> "$GITHUB_OUTPUT"
+
       - name: Load partitioned employees database
         run: |
           EXTRA_ARGS=""
-          [[ "$MYSQL_VERSION" == 9.* ]] && EXTRA_ARGS="--commands"
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
           ~/sandboxes/msb_*/use $EXTRA_ARGS < employees_partitioned.sql
 
       - name: Verify partitioning
@@ -225,9 +261,10 @@ jobs:
           [ "$PART_COUNT" -ge 18 ] || { echo "FAIL: expected >= 18 partitions on salaries"; exit 1; }
 
       - name: Test MD5 integrity
+        if: steps.features.outputs.has_md5 == 'true'
         run: |
           EXTRA_ARGS=""
-          [[ "$MYSQL_VERSION" == 9.* ]] && EXTRA_ARGS="--commands"
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
           ~/sandboxes/msb_*/use $EXTRA_ARGS -t < test_employees_md5.sql > /tmp/test_md5.txt
           cat /tmp/test_md5.txt
           md5_ok=$(grep -iw ok /tmp/test_md5.txt | wc -l | tr -d ' \t')
@@ -313,16 +350,28 @@ jobs:
           dbdeployer deploy single "$MYSQL_VERSION" \
             --sandbox-binary="$SANDBOX_BINARY"
 
+      - name: Detect MySQL features
+        id: features
+        run: |
+          MAJOR=$(echo "$MYSQL_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$MYSQL_VERSION" | cut -d. -f2)
+          NEEDS_COMMANDS="false"
+          if [ "$MAJOR" -gt 9 ] || { [ "$MAJOR" -eq 9 ] && [ "$MINOR" -ge 5 ]; }; then
+            NEEDS_COMMANDS="true"
+          fi
+          echo "needs_commands=$NEEDS_COMMANDS" >> "$GITHUB_OUTPUT"
+          echo "MySQL $MYSQL_VERSION: needs_commands=$NEEDS_COMMANDS"
+
       - name: Load Sakila schema
         run: |
           EXTRA_ARGS=""
-          [[ "$MYSQL_VERSION" == 9.* ]] && EXTRA_ARGS="--commands"
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
           ~/sandboxes/msb_*/use $EXTRA_ARGS < sakila/sakila-mv-schema.sql
 
       - name: Load Sakila data
         run: |
           EXTRA_ARGS=""
-          [[ "$MYSQL_VERSION" == 9.* ]] && EXTRA_ARGS="--commands"
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
           ~/sandboxes/msb_*/use $EXTRA_ARGS < sakila/sakila-mv-data.sql
 
       - name: Verify Sakila data

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/mysql-tarball
-          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v2
+          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v3
 
       - name: Download MySQL
         run: |
@@ -90,14 +90,17 @@ jobs:
           if [ "$MAJOR" -gt 9 ] || { [ "$MAJOR" -eq 9 ] && [ "$MINOR" -ge 5 ]; }; then
             NEEDS_COMMANDS="true"
           fi
-          # Check if MD5() is available (removed in MySQL 9.6+)
+          # Check if MD5()/SHA() are available (both removed in MySQL 9.6+)
           HAS_MD5="true"
+          HAS_SHA="true"
           if [ "$MAJOR" -gt 9 ] || { [ "$MAJOR" -eq 9 ] && [ "$MINOR" -ge 6 ]; }; then
             HAS_MD5="false"
+            HAS_SHA="false"
           fi
           echo "needs_commands=$NEEDS_COMMANDS" >> "$GITHUB_OUTPUT"
           echo "has_md5=$HAS_MD5" >> "$GITHUB_OUTPUT"
-          echo "MySQL $MYSQL_VERSION: needs_commands=$NEEDS_COMMANDS, has_md5=$HAS_MD5"
+          echo "has_sha=$HAS_SHA" >> "$GITHUB_OUTPUT"
+          echo "MySQL $MYSQL_VERSION: needs_commands=$NEEDS_COMMANDS, has_md5=$HAS_MD5, has_sha=$HAS_SHA"
 
       - name: Load employees database
         run: |
@@ -120,6 +123,7 @@ jobs:
           echo "MD5 OK ($md5_ok matches)"
 
       - name: Test SHA integrity
+        if: steps.features.outputs.has_sha == 'true'
         run: |
           EXTRA_ARGS=""
           [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
@@ -131,6 +135,18 @@ jobs:
             exit 1
           fi
           echo "SHA OK ($sha_ok matches)"
+
+      - name: Verify row counts (MySQL 9.6+ fallback)
+        if: steps.features.outputs.has_sha == 'false'
+        run: |
+          SBDIR=$(ls -d ~/sandboxes/msb_*)
+          $SBDIR/use -BN -e "SELECT COUNT(*) FROM employees;" employees | grep -q 300024
+          $SBDIR/use -BN -e "SELECT COUNT(*) FROM departments;" employees | grep -q 9
+          $SBDIR/use -BN -e "SELECT COUNT(*) FROM dept_manager;" employees | grep -q 24
+          $SBDIR/use -BN -e "SELECT COUNT(*) FROM dept_emp;" employees | grep -q 331603
+          $SBDIR/use -BN -e "SELECT COUNT(*) FROM titles;" employees | grep -q 443308
+          $SBDIR/use -BN -e "SELECT COUNT(*) FROM salaries;" employees | grep -q 2844047
+          echo "Row counts OK"
 
       - name: Load objects (stored procedures/functions)
         run: |
@@ -188,7 +204,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/mysql-tarball
-          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v2
+          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v3
 
       - name: Download MySQL
         run: |
@@ -314,7 +330,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/mysql-tarball
-          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v2
+          key: mysql-${{ matrix.mysql-version }}-linux-x86_64-v3
 
       - name: Download MySQL
         run: |

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -136,17 +136,18 @@ jobs:
           fi
           echo "SHA OK ($sha_ok matches)"
 
-      - name: Verify row counts (MySQL 9.6+ fallback)
-        if: steps.features.outputs.has_sha == 'false'
+      - name: Test SHA2 integrity
         run: |
-          SBDIR=$(ls -d ~/sandboxes/msb_*)
-          $SBDIR/use -BN -e "SELECT COUNT(*) FROM employees;" employees | grep -q 300024
-          $SBDIR/use -BN -e "SELECT COUNT(*) FROM departments;" employees | grep -q 9
-          $SBDIR/use -BN -e "SELECT COUNT(*) FROM dept_manager;" employees | grep -q 24
-          $SBDIR/use -BN -e "SELECT COUNT(*) FROM dept_emp;" employees | grep -q 331603
-          $SBDIR/use -BN -e "SELECT COUNT(*) FROM titles;" employees | grep -q 443308
-          $SBDIR/use -BN -e "SELECT COUNT(*) FROM salaries;" employees | grep -q 2844047
-          echo "Row counts OK"
+          EXTRA_ARGS=""
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
+          ~/sandboxes/msb_*/use $EXTRA_ARGS -t < test_employees_sha2.sql > /tmp/test_sha2.txt
+          cat /tmp/test_sha2.txt
+          sha2_ok=$(grep -iw ok /tmp/test_sha2.txt | wc -l | tr -d ' \t')
+          if [ "$sha2_ok" != "8" ]; then
+            echo "SHA2 FAIL - expected 8 OK - found $sha2_ok"
+            exit 1
+          fi
+          echo "SHA2 OK ($sha2_ok matches)"
 
       - name: Load objects (stored procedures/functions)
         run: |
@@ -289,6 +290,19 @@ jobs:
             exit 1
           fi
           echo "MD5 OK ($md5_ok matches)"
+
+      - name: Test SHA2 integrity
+        run: |
+          EXTRA_ARGS=""
+          [ "${{ steps.features.outputs.needs_commands }}" == "true" ] && EXTRA_ARGS="--commands"
+          ~/sandboxes/msb_*/use $EXTRA_ARGS -t < test_employees_sha2.sql > /tmp/test_sha2.txt
+          cat /tmp/test_sha2.txt
+          sha2_ok=$(grep -iw ok /tmp/test_sha2.txt | wc -l | tr -d ' \t')
+          if [ "$sha2_ok" != "8" ]; then
+            echo "SHA2 FAIL - expected 8 OK - found $sha2_ok"
+            exit 1
+          fi
+          echo "SHA2 OK ($sha2_ok matches)"
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -16,6 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         mysql-version:
+          - '5.6.51'
+          - '5.7.44'
           - '8.0.42'
           - '8.4.8'
           - '9.0.1'
@@ -49,17 +51,25 @@ jobs:
         run: |
           SHORT_VER="${MYSQL_VERSION%.*}"
           mkdir -p /tmp/mysql-tarball
-          CACHED=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz 2>/dev/null | head -1)
+          CACHED=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.* 2>/dev/null | head -1)
           if [ -n "$CACHED" ]; then
             echo "Using cached tarball: $CACHED"
             ls -lh "$CACHED"
             exit 0
           fi
-          # Try glibc2.17 first, then glibc2.28 (needed for MySQL 9.6+)
-          for GLIBC in glibc2.17 glibc2.28; do
-            TARBALL="mysql-${MYSQL_VERSION}-linux-${GLIBC}-x86_64.tar.xz"
+          # MySQL 5.x uses .tar.gz / glibc2.12; 8.x+ uses .tar.xz / glibc2.17; 9.6+ uses glibc2.28
+          MAJOR=$(echo "$MYSQL_VERSION" | cut -d. -f1)
+          if [ "$MAJOR" -lt 8 ]; then
+            GLIBCS="glibc2.12"
+            EXT="tar.gz"
+          else
+            GLIBCS="glibc2.17 glibc2.28"
+            EXT="tar.xz"
+          fi
+          for GLIBC in $GLIBCS; do
+            TARBALL="mysql-${MYSQL_VERSION}-linux-${GLIBC}-x86_64.${EXT}"
             URL="https://dev.mysql.com/get/Downloads/MySQL-${SHORT_VER}/${TARBALL}"
-            echo "Trying ${GLIBC}..."
+            echo "Trying ${GLIBC} (${EXT})..."
             if curl -L -f -o "/tmp/mysql-tarball/$TARBALL" "$URL"; then
               ls -lh "/tmp/mysql-tarball/$TARBALL"
               exit 0
@@ -71,7 +81,7 @@ jobs:
       - name: Unpack MySQL
         run: |
           mkdir -p "$SANDBOX_BINARY"
-          TARBALL=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz | head -1)
+          TARBALL=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.* | head -1)
           dbdeployer unpack "$TARBALL" \
             --sandbox-binary="$SANDBOX_BINARY"
 
@@ -178,6 +188,8 @@ jobs:
       fail-fast: false
       matrix:
         mysql-version:
+          - '5.6.51'
+          - '5.7.44'
           - '8.0.42'
           - '8.4.8'
           - '9.0.1'
@@ -211,14 +223,22 @@ jobs:
         run: |
           SHORT_VER="${MYSQL_VERSION%.*}"
           mkdir -p /tmp/mysql-tarball
-          CACHED=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz 2>/dev/null | head -1)
+          CACHED=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.* 2>/dev/null | head -1)
           if [ -n "$CACHED" ]; then
             echo "Using cached tarball: $CACHED"
             ls -lh "$CACHED"
             exit 0
           fi
-          for GLIBC in glibc2.17 glibc2.28; do
-            TARBALL="mysql-${MYSQL_VERSION}-linux-${GLIBC}-x86_64.tar.xz"
+          MAJOR=$(echo "$MYSQL_VERSION" | cut -d. -f1)
+          if [ "$MAJOR" -lt 8 ]; then
+            GLIBCS="glibc2.12"
+            EXT="tar.gz"
+          else
+            GLIBCS="glibc2.17 glibc2.28"
+            EXT="tar.xz"
+          fi
+          for GLIBC in $GLIBCS; do
+            TARBALL="mysql-${MYSQL_VERSION}-linux-${GLIBC}-x86_64.${EXT}"
             URL="https://dev.mysql.com/get/Downloads/MySQL-${SHORT_VER}/${TARBALL}"
             echo "Trying ${GLIBC}..."
             if curl -L -f -o "/tmp/mysql-tarball/$TARBALL" "$URL"; then
@@ -232,7 +252,7 @@ jobs:
       - name: Unpack MySQL
         run: |
           mkdir -p "$SANDBOX_BINARY"
-          TARBALL=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz | head -1)
+          TARBALL=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.* | head -1)
           dbdeployer unpack "$TARBALL" \
             --sandbox-binary="$SANDBOX_BINARY"
 
@@ -317,6 +337,8 @@ jobs:
       fail-fast: false
       matrix:
         mysql-version:
+          - '5.6.51'
+          - '5.7.44'
           - '8.0.42'
           - '8.4.8'
           - '9.0.1'
@@ -350,14 +372,22 @@ jobs:
         run: |
           SHORT_VER="${MYSQL_VERSION%.*}"
           mkdir -p /tmp/mysql-tarball
-          CACHED=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz 2>/dev/null | head -1)
+          CACHED=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.* 2>/dev/null | head -1)
           if [ -n "$CACHED" ]; then
             echo "Using cached tarball: $CACHED"
             ls -lh "$CACHED"
             exit 0
           fi
-          for GLIBC in glibc2.17 glibc2.28; do
-            TARBALL="mysql-${MYSQL_VERSION}-linux-${GLIBC}-x86_64.tar.xz"
+          MAJOR=$(echo "$MYSQL_VERSION" | cut -d. -f1)
+          if [ "$MAJOR" -lt 8 ]; then
+            GLIBCS="glibc2.12"
+            EXT="tar.gz"
+          else
+            GLIBCS="glibc2.17 glibc2.28"
+            EXT="tar.xz"
+          fi
+          for GLIBC in $GLIBCS; do
+            TARBALL="mysql-${MYSQL_VERSION}-linux-${GLIBC}-x86_64.${EXT}"
             URL="https://dev.mysql.com/get/Downloads/MySQL-${SHORT_VER}/${TARBALL}"
             echo "Trying ${GLIBC}..."
             if curl -L -f -o "/tmp/mysql-tarball/$TARBALL" "$URL"; then
@@ -371,7 +401,7 @@ jobs:
       - name: Unpack MySQL
         run: |
           mkdir -p "$SANDBOX_BINARY"
-          TARBALL=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.xz | head -1)
+          TARBALL=$(ls /tmp/mysql-tarball/mysql-${MYSQL_VERSION}-linux-*.tar.* | head -1)
           dbdeployer unpack "$TARBALL" \
             --sandbox-binary="$SANDBOX_BINARY"
 

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dbdeployer
         run: |
           curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
-          echo "$HOME/bin" >> "$GITHUB_PATH"
+          sudo mv dbdeployer /usr/local/bin/dbdeployer
 
       - name: Cache MySQL tarball
         uses: actions/cache@v4
@@ -150,7 +150,7 @@ jobs:
       - name: Install dbdeployer
         run: |
           curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
-          echo "$HOME/bin" >> "$GITHUB_PATH"
+          sudo mv dbdeployer /usr/local/bin/dbdeployer
 
       - name: Cache MySQL tarball
         uses: actions/cache@v4
@@ -250,7 +250,7 @@ jobs:
       - name: Install dbdeployer
         run: |
           curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
-          echo "$HOME/bin" >> "$GITHUB_PATH"
+          sudo mv dbdeployer /usr/local/bin/dbdeployer
 
       - name: Cache MySQL tarball
         uses: actions/cache@v4

--- a/.github/workflows/ci-percona.yml
+++ b/.github/workflows/ci-percona.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dbdeployer
         run: |
           curl -s https://raw.githubusercontent.com/ProxySQL/dbdeployer/master/scripts/dbdeployer-install.sh | bash
-          echo "$HOME/bin" >> "$GITHUB_PATH"
+          sudo mv dbdeployer /usr/local/bin/dbdeployer
 
       - name: Cache Percona tarball
         uses: actions/cache@v4

--- a/.github/workflows/ci-percona.yml
+++ b/.github/workflows/ci-percona.yml
@@ -100,8 +100,10 @@ jobs:
 
       - name: Verify Percona Server version
         run: |
-          ~/sandboxes/msb_*/use -BN -e "SELECT VERSION();" | grep -i percona
-          echo "OK: Percona Server detected"
+          VERSION=$(~/sandboxes/msb_*/use -BN -e "SELECT VERSION();")
+          echo "Server version: $VERSION"
+          echo "$VERSION" | grep -iq percona || echo "Note: version string does not contain 'percona'"
+          echo "OK: Server running"
 
       - name: Cleanup
         if: always()

--- a/README.md
+++ b/README.md
@@ -10,6 +10,33 @@ See usage in the [MySQL docs](https://dev.mysql.com/doc/employee/en/index.html)
 [![CI MariaDB](https://github.com/datacharmer/test_db/actions/workflows/ci-mariadb.yml/badge.svg)](https://github.com/datacharmer/test_db/actions/workflows/ci-mariadb.yml)
 
 
+## Supported Versions
+
+This database is regularly tested against the following server versions:
+
+| Vendor | Versions |
+|--------|----------|
+| MySQL | 8.0, 8.4, 9.0, 9.2, 9.5, 9.6 |
+| Percona Server | 8.0, 8.4 |
+| MariaDB | 10.11, 11.4, 12.1 |
+
+All versions are tested weekly via CI using [ProxySQL/dbdeployer](https://github.com/ProxySQL/dbdeployer).
+
+### MySQL 9.x Notes
+
+Starting with MySQL 9.5, the `SOURCE` command requires the `--commands` flag on the client:
+
+    mysql --commands < employees.sql
+
+Starting with MySQL 9.6, the `MD5()` and `SHA()` functions have been removed from the server.
+The integrity test files `test_employees_md5.sql` and `test_employees_sha.sql` will not work on 9.6+.
+Use `test_employees_sha2.sql` instead, which uses `SHA2(..., 256)` and is compatible with all versions:
+
+    mysql -t < test_employees_sha2.sql
+
+The SHA-256 checksums are identical across all supported MySQL, Percona, and MariaDB versions.
+
+
 ## Where it comes from
 
 The original data was created by Fusheng Wang and Carlo Zaniolo at 
@@ -58,11 +85,11 @@ If you want to install with two large partitioned tables, run
 
 ## Testing the installation
 
-After installing, you can run one of the following
+After installing, you can run one of the following integrity tests:
 
-    mysql -t < test_employees_md5.sql
-    # OR
-    mysql -t < test_employees_sha.sql
+    mysql -t < test_employees_sha2.sql   # SHA-256 (works on all versions including 9.6+)
+    mysql -t < test_employees_md5.sql    # MD5 (MySQL 8.0–9.5 only)
+    mysql -t < test_employees_sha.sql    # SHA-1 (MySQL 8.0–9.5 only)
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,16 @@ See usage in the [MySQL docs](https://dev.mysql.com/doc/employee/en/index.html)
 [![CI MariaDB](https://github.com/datacharmer/test_db/actions/workflows/ci-mariadb.yml/badge.svg)](https://github.com/datacharmer/test_db/actions/workflows/ci-mariadb.yml)
 
 
-## Supported Versions
+## Tested Versions
 
-This database is regularly tested against the following server versions:
+The database requires MySQL 5.0+ or compatible server. The following versions are tested in CI
+using [ProxySQL/dbdeployer](https://github.com/ProxySQL/dbdeployer) on a weekly schedule:
 
 | Vendor | Versions |
 |--------|----------|
-| MySQL | 8.0, 8.4, 9.0, 9.2, 9.5, 9.6 |
+| MySQL | 5.6, 5.7, 8.0, 8.4, 9.0, 9.2, 9.5, 9.6 |
 | Percona Server | 8.0, 8.4 |
 | MariaDB | 10.11, 11.4, 12.1 |
-
-All versions are tested weekly via CI using [ProxySQL/dbdeployer](https://github.com/ProxySQL/dbdeployer).
 
 ### MySQL 9.x Notes
 

--- a/test_employees_sha2.sql
+++ b/test_employees_sha2.sql
@@ -1,0 +1,87 @@
+--  Test employees database integrity using SHA-256 checksums
+--  Uses SHA2() which is available on all MySQL versions (8.0+)
+--  This test works on MySQL 9.6+ where md5() and sha() have been removed
+
+USE employees;
+
+SELECT 'TESTING INSTALLATION' as 'INFO';
+
+DROP TABLE IF EXISTS expected_values, found_values;
+CREATE TABLE expected_values (
+    table_name varchar(30) not null primary key,
+    recs int not null,
+    crc_sha2 varchar(100) not null
+);
+
+
+CREATE TABLE found_values (LIKE expected_values);
+
+-- Expected SHA-256 checksums (computed from the canonical data set)
+INSERT INTO `expected_values` VALUES
+('employees',   300024, '21f5d003842f24853e251d3d5116798bafe257ec3d1bb448b5365b68deaabbf4'),
+('departments',      9, '377c5d727383a32633e2973f8e3411beffe29e2f4cc297c586fa6b24aa7df9ba'),
+('dept_manager',    24, '3a4e69723deec413a7d8a4f5ce55013830303fa617b6380ed2b0fd2d48b1c768'),
+('dept_emp',    331603, '34548ee9989dd4d5e065168b43249c8d3eb48bfbbfb3f2fc1cf01be6658f6a75'),
+('titles',      443308, 'a9e940ef9ba1029a8f0356fdbe495430bedc59eec5ceb4f71e0cc35ddcbf9980'),
+('salaries',   2844047, '4e99e691a9ea98fefc0b4fec8ca4e758baeefba2967bd8d6474810a9a5f6e729');
+SELECT table_name, recs AS expected_records, crc_sha2 AS expected_crc FROM expected_values;
+
+DROP TABLE IF EXISTS tchecksum;
+CREATE TABLE tchecksum (chk char(100));
+
+SET @crc= '';
+INSERT INTO tchecksum
+    SELECT @crc := SHA2(CONCAT_WS('#',@crc,
+                emp_no,birth_date,first_name,last_name,gender,hire_date), 256)
+    FROM employees ORDER BY emp_no;
+INSERT INTO found_values VALUES ('employees', (SELECT COUNT(*) FROM employees), @crc);
+
+SET @crc = '';
+INSERT INTO tchecksum
+    SELECT @crc := SHA2(CONCAT_WS('#',@crc, dept_no,dept_name), 256)
+    FROM departments ORDER BY dept_no;
+INSERT INTO found_values VALUES ('departments', (SELECT COUNT(*) FROM departments), @crc);
+
+SET @crc = '';
+INSERT INTO tchecksum
+    SELECT @crc := SHA2(CONCAT_WS('#',@crc, dept_no,emp_no, from_date,to_date), 256)
+    FROM dept_manager ORDER BY dept_no,emp_no;
+INSERT INTO found_values VALUES ('dept_manager', (SELECT COUNT(*) FROM dept_manager), @crc);
+
+SET @crc = '';
+INSERT INTO tchecksum
+    SELECT @crc := SHA2(CONCAT_WS('#',@crc, dept_no,emp_no, from_date,to_date), 256)
+    FROM dept_emp ORDER BY dept_no,emp_no;
+INSERT INTO found_values VALUES ('dept_emp', (SELECT COUNT(*) FROM dept_emp), @crc);
+
+SET @crc = '';
+INSERT INTO tchecksum
+    SELECT @crc := SHA2(CONCAT_WS('#',@crc, emp_no, title, from_date,to_date), 256)
+    FROM titles ORDER BY emp_no,title, from_date;
+INSERT INTO found_values VALUES ('titles', (SELECT COUNT(*) FROM titles), @crc);
+
+SET @crc = '';
+INSERT INTO tchecksum
+    SELECT @crc := SHA2(CONCAT_WS('#',@crc, emp_no, salary, from_date,to_date), 256)
+    FROM salaries ORDER BY emp_no,from_date,to_date;
+INSERT INTO found_values VALUES ('salaries', (SELECT COUNT(*) FROM salaries), @crc);
+
+DROP TABLE tchecksum;
+
+SELECT table_name, recs AS found_records, crc_sha2 AS found_crc FROM found_values;
+
+SELECT
+    e.table_name,
+    IF(e.recs=f.recs,'OK', 'not ok') AS records_match,
+    IF(e.crc_sha2=f.crc_sha2,'ok','not ok') AS crc_match
+FROM
+    expected_values e INNER JOIN found_values f USING (table_name);
+
+SET @crc_fail=(SELECT COUNT(*) FROM expected_values e INNER JOIN found_values f ON (e.table_name=f.table_name) WHERE f.crc_sha2 != e.crc_sha2);
+SET @count_fail=(SELECT COUNT(*) FROM expected_values e INNER JOIN found_values f ON (e.table_name=f.table_name) WHERE f.recs != e.recs);
+
+SELECT 'CRC' AS summary, IF(@crc_fail = 0, "OK", "FAIL") AS `result`
+UNION ALL
+SELECT 'count', IF(@count_fail = 0, "OK", "FAIL") AS `count`;
+
+DROP TABLE expected_values, found_values;


### PR DESCRIPTION
## Summary
- Fix `dbdeployer: command not found` in all three CI workflows
- The install script extracts to CWD but doesn't add to `$PATH` — now explicitly moves to `/usr/local/bin`

## Test plan
- [ ] Verify CI MySQL workflow passes for all matrix versions
- [ ] Verify CI Percona workflow passes
- [ ] Verify CI MariaDB workflow passes

Closes #51